### PR TITLE
ci: add repo-owned Go gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  go-check:
+    name: go check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run repository gate
+        run: make check

--- a/.github/workflows/leyline.yml
+++ b/.github/workflows/leyline.yml
@@ -1,10 +1,10 @@
 name: Leyline Sync
 on:
-  pull_request:
   push:
+    branches: [master]
+  workflow_dispatch:
 jobs:
   docs:
     uses: phrazzld/leyline/.github/workflows/vendor.yml@master
     with:
       ref: master
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 - Run app: `scratch`
 - Format code: `go fmt ./...`
 - Run tests: `go test ./...`
+- Verify everything: `make check`
 - Run specific test: `go test -run TestName`
 - Lint: `golangci-lint run`
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+GO ?= go
+GOFMT ?= gofmt
+
+.PHONY: check fmt-check test vet
+
+check: fmt-check test vet
+
+fmt-check:
+	@files="$$($(GOFMT) -l .)" || exit $$?; \
+	if [ -n "$$files" ]; then \
+		echo "gofmt needed:"; \
+		echo "$$files"; \
+		exit 1; \
+	fi
+
+test:
+	$(GO) test ./...
+
+vet:
+	$(GO) vet ./...

--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ sudo ln -s $HOME/go/bin/scratch /usr/local/bin/scratch
 
 - simply type `scratch` in your terminal
 - your scratchpads are in `~/documents/rubberducks/YYYYMMDD-scratch.md`
+
+## development
+
+Run the repo-owned gate before merging:
+
+```bash
+make check
+```
+
+CI uses the same command in the `go check` job. The separate Leyline workflow
+only vendors shared docs; it does not replace the Go gate.


### PR DESCRIPTION
## Summary
- Pushed from a fresh isolated clone because the original local checkout has a bad zero ref.

## Verification
- `make check`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Thermo-Nuclear Review
- Fresh-context thermo review completed before PR; blocking findings addressed or this branch was held back.

Agent: codex
Agent-Surface: Herdr
Agent-Runner: Codex CLI
Agent-Model: GPT-5
Agent-Task: ci-worldclass-rollout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CI checks for pull requests and master branch pushes, including Go formatting, tests, and vetting.
  * Added a unified project gate command for local and CI validation.

* **Documentation**
  * Updated setup guidance to tell contributors to run the new check command before merging.
  * Clarified which workflow handles code checks versus documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->